### PR TITLE
Update parse.h

### DIFF
--- a/parse.h
+++ b/parse.h
@@ -15,7 +15,7 @@
 void parse(FILE* fp, int size);
 
 /* Checks format of given string */
-int parse_test(char *input, int length);
+int parse_test(char *input);
 
 /* Gets the numbers from line given */
 void getDigits(char* str, int size);


### PR DESCRIPTION
removed an unnecessary parameter in parse_test. 
old: int parse_text(char *input, int length)
new: int parse_text(char *input)
